### PR TITLE
COMP: Add itkImageRegionConstIteratorWithIndex.h include for ITK6 compat

### DIFF
--- a/BVeR/BVeR.cxx
+++ b/BVeR/BVeR.cxx
@@ -6,6 +6,7 @@
 #include "itkBinaryThresholdImageFilter.h"
 #include "itkBinaryContourImageFilter.h"
 #include "itkImageRegionIterator.h"
+#include "itkImageRegionConstIteratorWithIndex.h"
 #include "itkNeighborhoodIterator.h"
 #include "itkConstantBoundaryCondition.h"
 #include "itkConstNeighborhoodIterator.h"


### PR DESCRIPTION
Add `#include "itkImageRegionConstIteratorWithIndex.h"` to `BVeR/BVeR.cxx` so the extension builds against ITK upstream main (v6 prep).

<details>
<summary>Why this is needed</summary>

ITK upstream main has trimmed transitive includes. `BVeR.cxx:185` uses `itk::ImageRegionConstIteratorWithIndex` but did not include its declaring header directly. Under ITK 5.x this was transitively pulled in via one of the other ITK includes; under ITK main this fails:

```
BVeR.cxx:185:14: error: 'ImageRegionConstIteratorWithIndex' is not a member of 'itk'; did you mean 'ImageLinearConstIteratorWithIndex'?
```

Adding the explicit include is fully backward compatible with ITK 5.x (the header has always existed under that name).

</details>

<details>
<summary>Tracking</summary>

Part of the Slicer ITK upstream-main (v6) transition tracked at
[Slicer/Slicer#9149](https://github.com/Slicer/Slicer/issues/9149). The same
transitive-include cleanup pattern was fixed in `Slicer/Slicer` core (2 sites)
and `ANTsX/ANTs` master (`Utilities/itkSurfaceImageCurvature.h`).

</details>
